### PR TITLE
Locale passed in as parameter in args is now taken into account when rendering.

### DIFF
--- a/grails-app/i18n/messages_fr.properties
+++ b/grails-app/i18n/messages_fr.properties
@@ -1,0 +1,1 @@
+label = french

--- a/grails-app/services/grails/plugin/rendering/document/XhtmlDocumentService.groovy
+++ b/grails-app/services/grails/plugin/rendering/document/XhtmlDocumentService.groovy
@@ -65,7 +65,7 @@ class XhtmlDocumentService {
 	protected generateXhtml(Map args) {
 		def xhtmlWriter = new StringWriter()
 
-		RenderEnvironment.with(grailsApplication.mainContext, xhtmlWriter) {
+		RenderEnvironment.with(grailsApplication.mainContext, xhtmlWriter, args.locale) {
 			createTemplate(args).make(args.model).writeTo(xhtmlWriter)
 		}
 		

--- a/grails-app/views/_simple.gsp
+++ b/grails-app/views/_simple.gsp
@@ -19,5 +19,6 @@
     <body>
         <p>This is a PDF!</p>
         <p>${var}</p>
+        <p>Locale specific content: ${message(code: 'label')}</p>
     </body>
 </html>

--- a/test/integration/grails/plugin/rendering/RenderingServiceSpec.groovy
+++ b/test/integration/grails/plugin/rendering/RenderingServiceSpec.groovy
@@ -42,7 +42,7 @@ abstract class RenderingServiceSpec extends IntegrationSpec {
 		then:
 		notThrown(Exception)
 	}
-	
+
 	def renderTemplateInPlugin() {
 		when:
 		renderer.render(pluginTemplate)
@@ -63,7 +63,7 @@ abstract class RenderingServiceSpec extends IntegrationSpec {
 		then:
 		thrown(UnknownTemplateException)
 	}
-	
+
 
 	def renderToResponse() {
 		given:

--- a/test/integration/grails/plugin/rendering/pdf/PdfRenderingServiceSpec.groovy
+++ b/test/integration/grails/plugin/rendering/pdf/PdfRenderingServiceSpec.groovy
@@ -32,6 +32,16 @@ class PdfRenderingServiceSpec extends RenderingServiceSpec {
 	def getRenderer() {
 		pdfRenderingService
 	}
+
+	def renderWithLocaleArgument(){
+		given:
+		def response = createMockResponse()
+		when:
+		renderer.render(getSimpleTemplate([locale: Locale.FRENCH]), response)
+		def matcher = new PDFTextStripper().getText(PDDocument.load(new ByteArrayInputStream(response.contentAsByteArray))) =~ /french/
+		then:
+		matcher.size() == 1
+	}
 	
 	protected extractTextLines(Map renderArgs) {
 		extractTextLines(createPdf(renderArgs))


### PR DESCRIPTION
The XhtmlDocumentService never allowed the locale in the request used by RenderEnvironment to be overridden with a custom locale. This patch will enable to Locale to be used for rendering to be overridden by the locale argument.

The test in PdfRenderingServiceSpec feels clunky, any suggestions on making it better are welcome.
