### PR TITLE
activating flying saucer logging

### DIFF
--- a/src/docs/guide/3. Rendering.gdoc
+++ b/src/docs/guide/3. Rendering.gdoc
@@ -49,3 +49,10 @@ That is,
 * template paths NOT starting with "/" are resolved relative to the @views/«controller»@ directory
 
 If the @template@ argument does not start with a "/", the @controller@ argument must be provided. The methods added to controllers (e.g. @renderPdf()@) automatically pass the @controller@ param for you.
+
+h3. Debuging
+
+To get more visibility about what is going on inside, you can activate the logging within Flying Saucer by providing the system property xr.util-logging.loggingEnabled like so:
+{code}
+grails -Dxr.util-logging.loggingEnabled=true run-app
+{code}


### PR DESCRIPTION
I had a "semicolon moment" where I was digging deep in this plugin and flying saucer only to eventually discover my css was missing a semicolon, which was causing the parser to just drop the css. The way I finally discovered this small bug in my code, was by enabling logging in flying saucer. 

I have added a note on how to provide system property to activate logging within flying saucer. flying saucer. Could have done it programmatically in the code with something like if (log.debugEnabled) System.setProperty... .

For some reason, the logging does seem to happen until the second time a
document is rendered. Still very useful though!
