### PR TITLE
Use OpenPDF instead of iText for generating PDF.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,13 @@ dependencyManagement {
 }
 
 dependencies {
+    // flying-saucer-pdf declares a profile using openpdf instead of itext, but we cannot declare it in gradle, so we
+    // need to manually exclude itext and add openpdf dependency
+    compile("org.xhtmlrenderer:flying-saucer-pdf:9.1.7") {
+        exclude group: 'com.lowagie', module: 'itext'
+    }
+    compile('com.github.librepdf:openpdf:1.0.3')
 
-    compile("org.xhtmlrenderer:core-renderer:R8")
-    compile("com.lowagie:itext:2.1.0")
     testCompile("org.apache.pdfbox:pdfbox:1.0.0") {
         exclude module:'jempbox'
     }

--- a/src/main/groovy/grails/plugins/rendering/datauri/DataUriAwareITextUserAgent.groovy
+++ b/src/main/groovy/grails/plugins/rendering/datauri/DataUriAwareITextUserAgent.groovy
@@ -47,17 +47,17 @@ class DataUriAwareITextUserAgent extends ITextUserAgent {
 					def image = Image.getInstance(dataUri.bytes)
 					def factor = sharedContext.dotsPerPixel
 					image.scaleAbsolute((image.plainWidth * factor) as float, (image.plainHeight * factor) as float)
-					resource = new ImageResource(new ITextFSImage(image))
+					resource = new ImageResource(uri, new ITextFSImage(image))
 					_imageCache.put(uri, resource)
 					resource
 				} catch (Exception e) {
 					GrailsUtil.deepSanitize(e)
 					log.error("exception creating image from data uri (will use empty image): $dataUri", e)
-					new ImageResource(null)
+					new ImageResource(uri, null)
 				}
 			} else {
 				log.error("data uri has a non image mime type (will use empty image): $dataUri")
-				new ImageResource(null)
+				new ImageResource(uri, null)
 			}
 		} else {
 			super.getImageResource(uri)


### PR DESCRIPTION
This PR introduces usage of OpenPDF which is a fork of iText. The project seems to be actively developed and released under LGPL licence. Flying-saucer-pdf supports it as a replacement for iText by using Maven profile, but could find how to use it that way, hence the manual exclude and dependency declaration.