### PR TITLE
Updated documentation, Asciidoctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Rendering Grails Plugin
 =======================
 
-This plugin adds PDF, GIF, PNG and JPEG rendering facilities to Grails applications via the [XHTML Renderer](https://xhtmlrenderer.dev.java.net/) library.
+This plugin adds PDF, GIF, PNG and JPEG rendering facilities to Grails applications via the [XHTML Renderer](https://github.com/flyingsaucerproject/flyingsaucer) library.
 
 Rendering is either done directly via one of the `«format»RenderingService` services …
 
@@ -15,5 +15,5 @@ Or via one of the `render«format»()` methods added to controllers …
 
 Please see the [User Guide](http://gpc.github.io/rendering/ "Grails Rendering Plugin @ GitHub") for more information.
 
-The plugin is released under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html "Apache License, Version 2.0 - The Apache Software Foundation") and is produced under the [Grails Plugin Collective](http://gpc.github.com/). 
-However, it does [LGPL](http://www.gnu.org/licenses/lgpl.html) libraries: [XhtmlRenderer](https://code.google.com/p/flying-saucer/) and [iText](http://sourceforge.net/projects/itext/).
+The plugin is released under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html "Apache License, Version 2.0 - The Apache Software Foundation") and is produced under the [Grails Plugin Collective](https://github.com/gpc).
+However, it does include [LGPL](http://www.gnu.org/licenses/lgpl.html) libraries: [XhtmlRenderer](https://github.com/flyingsaucerproject/flyingsaucer)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=7.0.0-SNAPSHOT
 grailsVersion=7.0.0-RC2
 javaVersion=17
-asciidoctorGradlePluginVersion=4.0.4
+asciidoctorGradlePluginVersion=4.0.5
 

--- a/src/main/asciidoc/1. Introduction.adoc
+++ b/src/main/asciidoc/1. Introduction.adoc
@@ -1,6 +1,6 @@
 = Introduction
 
-This plugin adds additional rendering capabilities to Grails applications via the https://xhtmlrenderer.dev.java.net/[XHTML Renderer] library.
+This plugin adds additional rendering capabilities to Grails applications via the https://github.com/flyingsaucerproject/flyingsaucer[XHTML Renderer] library.
 
 Rendering is either done directly via `«format»RenderingService` services ...
 

--- a/src/main/asciidoc/3. Rendering.adoc
+++ b/src/main/asciidoc/3. Rendering.adoc
@@ -30,7 +30,7 @@ new File("coupon.jpg").withOutputStream { outputStream ->
 }
 ----
 
-For information on rendering to the HTTP response, see <<guide:5. Rendering To The Response,Rendering To The Response>>.
+For information on rendering to the HTTP response, see <<rendering-to-the-response,Rendering To The Response>>.
 
 === Basic Render Arguments
 


### PR DESCRIPTION
- Asciidoctor updated to latest patch release
- Documentation updated
  - XhtmlRenderer is now hosted at GitHub.com/flyingsaucerproject/
  - iText is no longer a dependency
  - Fixed broken a href ancor link in Asciidocs