### PR TITLE
Chores - prepare for Grails 7 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ dependencies {
     compileOnly platform("org.apache.grails:grails-bom:$grailsVersion")
     compileOnly 'org.apache.grails:grails-dependencies-starter-web'
 
-    api('org.xhtmlrenderer:flying-saucer-pdf-openpdf:9.4.0') 
-    api("org.apache.pdfbox:pdfbox:3.0.5") 
+    api('org.xhtmlrenderer:flying-saucer-pdf:9.9.5')
+    api("org.apache.pdfbox:pdfbox:3.0.6")
 
     testImplementation platform("org.apache.grails:grails-bom:$grailsVersion")
     testImplementation "org.apache.grails:grails-testing-support-datamapping"

--- a/example/README.md
+++ b/example/README.md
@@ -1,13 +1,13 @@
 ## Grails 7.0.0-RC2 Documentation
 
-- [User Guide](https://docs.grails.org/7.0.0-RC2/guide/index.html)
-- [API Reference](https://docs.grails.org/7.0.0-RC2/api/index.html)
+- [User Guide](https://grails.apache.org/docs/7.0.0/guide/)
+- [API Reference](https://grails.apache.org/docs/7.0.0/api/)
 - [Grails Guides](https://guides.grails.org/index.html)
 ---
 
 ## Feature scaffolding documentation
 
-- [Grails Scaffolding documentation](https://docs.grails.org/7.0.0-RC2/guide/scaffolding.html)
+- [Grails Scaffolding documentation](https://grails.apache.org/docs/7.0.0/guide/scaffolding.html)
 
 ## Feature asset-pipeline-grails documentation
 
@@ -19,7 +19,7 @@
 
 ## Feature geb-with-testcontainers documentation
 
-- [Grails Geb Functional Testing for Grails with Testcontainers documentation](https://github.com/apache/grails-geb#readme)
+- [Grails Geb Functional Testing for Grails with Testcontainers documentation](https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme)
 
 - [https://groovy.apache.org/geb/manual/current/](https://groovy.apache.org/geb/manual/current/)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=7.0.0-SNAPSHOT
-grailsVersion=7.0.0-RC2
+grailsVersion=7.0.0
 javaVersion=17
 asciidoctorGradlePluginVersion=4.0.5
 

--- a/src/main/groovy/grails/plugins/rendering/RenderingGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/rendering/RenderingGrailsPlugin.groovy
@@ -36,11 +36,11 @@ class RenderingGrailsPlugin extends Plugin {
     def authorEmail = "grails.plugin.collective@gmail.com"
     def title = "Grails Rendering"
     def description = 'Render GSPs as PDFs, JPEGs, GIFs and PNGs'
-    def documentation = "http://gpc.github.com/grails-rendering"
+    def documentation = "https://gpc.github.io/rendering/"
 
     def license = 'APACHE'
     def organization = [name: 'Grails Plugin Collective', url: 'https://github.com/gpc']
-    def issueManagement = [system: 'JIRA', url: 'https://github.com/gpc/rendering/issues']
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/gpc/rendering/issues']
     def scm = [url: 'https://github.com/gpc/rendering.git']
 
 }


### PR DESCRIPTION
- Grails 7.0.0 has been released
- flying-saucer-pdf new Maven coordinates and version
- pdf-box updated to latest minor version
- Updated links in README and plugin description