### PR TITLE
Replave Travis CI status badge with GitHub status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/gpc/rendering.svg?branch=master)](https://travis-ci.org/gpc/rendering)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.gpc/rendering)](https://central.sonatype.com/artifact/io.github.gpc/rendering)
+[![CI](https://github.com/gpc/rendering/actions/workflows/gradle.yml/badge.svg?event=push)](https://github.com/gpc/rendering/actions/workflows/gradle.yml)
 
 Rendering Grails Plugin
 =======================


### PR DESCRIPTION
Updated README build status badges, the build is now GitHub Actions and not Travis CI

* Replace the Travis CI badge with GitHub Action
* Add badge showing Maven release version